### PR TITLE
Windows workarounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,5 +9,7 @@ is unlocked.
 Build the standalone app with
 
 ```shell
-pyinstaller osh.spec
+pyinstaller osh_spec.py
 ```
+
+Note: on Windows you will need both the `osh.exe` and the `osh-display-list.exe` binaries to be in the same directory.

--- a/osh.spec
+++ b/osh.spec
@@ -1,7 +1,7 @@
 block_cipher = None
 
 
-a = Analysis(
+main_app_analysis = Analysis(
     ['src/obs_scene_helper/__main__.py'],
     pathex=['.'],
     binaries=[],
@@ -16,14 +16,33 @@ a = Analysis(
     cipher=block_cipher,
     noarchive=False,
 )
-pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
 
-exe = EXE(
-    pyz,
-    a.scripts,
-    a.binaries,
-    a.zipfiles,
-    a.datas,
+win_display_getter_analysis = Analysis(
+    ['src/obs_scene_helper/controller/system/provider/display_list/windows.py'],
+    pathex=['.'],
+    binaries=[],
+    datas=[],
+    hiddenimports=[],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False,
+)
+
+main_pyz = PYZ(main_app_analysis.pure, main_app_analysis.zipped_data, cipher=block_cipher)
+
+win_display_list_pyz = PYZ(win_display_getter_analysis.pure, win_display_getter_analysis.zipped_data, cipher=block_cipher)
+
+exe_main = EXE(
+    main_pyz,
+    main_app_analysis.scripts,
+    main_app_analysis.binaries,
+    main_app_analysis.zipfiles,
+    main_app_analysis.datas,
     [],
     name='osh',
     icon="res/app.ico",
@@ -40,8 +59,32 @@ exe = EXE(
     codesign_identity=None,
     entitlements_file=None,
 )
+
+exe_display_list = EXE(
+    win_display_list_pyz,
+    win_display_getter_analysis.scripts,
+    win_display_getter_analysis.binaries,
+    win_display_getter_analysis.zipfiles,
+    win_display_getter_analysis.datas,
+    [],
+    name='osh-display-list',
+    icon="res/app.ico",
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    runtime_tmpdir=None,
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)
+
 app = BUNDLE(
-    exe,
+    exe_main,
     name='osh.app',
     icon="res/app.icns",
     bundle_identifier=None,

--- a/src/obs_scene_helper/controller/system/display_list.py
+++ b/src/obs_scene_helper/controller/system/display_list.py
@@ -11,14 +11,15 @@ class DisplayList(QObject):
         super().__init__(*args, **kwargs)
 
         if platform == 'win32':
-            # TODO: WinAPI provider
-            self._provider = None
+            from obs_scene_helper.controller.system.provider.display_list.windows import WindowsProvider
+            self._provider = WindowsProvider(*args, **kwargs)
         else:
             from obs_scene_helper.controller.system.provider.display_list.qt import QtProvider
             self._provider = QtProvider(*args, **kwargs)
-            self._provider.changed.connect(self._handle_display_list_change)
 
         if self._provider is not None:
+            self._provider.changed.connect(self._handle_display_list_change)
+
             # Simulate a display list changed event.
             # This way the clients will start with a valid list of displays
             self._handle_display_list_change(self._provider.displays)

--- a/src/obs_scene_helper/controller/system/provider/display_list/windows.py
+++ b/src/obs_scene_helper/controller/system/provider/display_list/windows.py
@@ -1,0 +1,145 @@
+from typing import Callable
+
+import sys
+import os
+import subprocess
+import json
+
+from PySide6.QtCore import QObject, Signal
+from PySide6.QtWidgets import QMessageBox
+
+import win32con
+from win32gui import CreateWindowEx, WNDCLASS, RegisterClass, DefWindowProc, DestroyWindow
+from win32api import GetModuleHandle
+
+
+# On Windows 10 the Qt does not correctly react to display configuration changes, for example: switching from
+# the "PC screen only" to the "Second screen only" doesn't generate any events. So we have to react to the low-level
+# Windows API messages and get the display list manually by calling a dedicated function in another interpreter instance
+
+
+class ScreenChangeObserver:
+    """ Hidden window-based observer to capture WM_DISPLAYCHANGE messages. """
+
+    def __init__(self, callback: Callable[[int, int, int], None]):
+        self.callback = callback
+        self.hwnd = self._create_hidden_window()
+
+    def destroy(self):
+        if self.hwnd is not None:
+            DestroyWindow(self.hwnd)
+            self.hwnd = None
+
+    def _create_hidden_window(self):
+        class_name = "OSHHiddenDisplayChangeObserver"
+        hinstance = GetModuleHandle(None)
+
+        wndclass = WNDCLASS()
+        wndclass.lpfnWndProc = self._window_proc
+        wndclass.lpszClassName = class_name
+        wndclass.hInstance = hinstance
+        RegisterClass(wndclass)
+
+        hwnd = CreateWindowEx(0, class_name, None, win32con.WS_OVERLAPPED, win32con.CW_USEDEFAULT,
+                              win32con.CW_USEDEFAULT, win32con.CW_USEDEFAULT, win32con.CW_USEDEFAULT, None, None,
+                              hinstance, None)
+
+        return hwnd
+
+    def _window_proc(self, hwnd, msg, wparam, lparam):
+        """
+        Window procedure to handle messages.
+        """
+        if msg == win32con.WM_DISPLAYCHANGE:
+            # Extract resolution and bit depth
+            screen_width = lparam & 0xFFFF
+            screen_height = (lparam >> 16) & 0xFFFF
+            bpp = wparam
+            self.callback(screen_width, screen_height, bpp)
+
+        return DefWindowProc(hwnd, msg, wparam, lparam)
+
+
+class WindowsProvider(QObject):
+    changed = Signal(list)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self._screen_change_observer = ScreenChangeObserver(self._on_screen_configuration_changed)
+
+        self._displays = []
+        self._fetch_display_list()
+
+    def _on_screen_configuration_changed(self, *_):
+        print(f'Screen config changed!')
+        self._fetch_display_list()
+
+    @property
+    def displays(self):
+        return self._displays
+
+    # When bundled as a standalone binary we cannot just delegate a function call to a new python interpreter instance,
+    # we have to run another standalone binary to get the fresh display list :facepalm:
+    @staticmethod
+    def _is_running_from_exe():
+        return getattr(sys, 'frozen', False)
+
+    @staticmethod
+    def _get_display_list_standalone() -> str:
+        our_dir = os.path.dirname(sys.executable)
+        list_getter = os.path.join(our_dir, 'osh-display-list.exe')
+        return subprocess.run([list_getter], capture_output=True, text=True, check=True).stdout
+
+    @staticmethod
+    def _get_display_list_interpreted() -> str:
+        code = 'from obs_scene_helper.controller.system.provider.display_list.windows import get_display_list\r\n' \
+               'get_display_list()'
+
+        return subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, check=True).stdout
+
+    def _fetch_display_list(self):
+        try:
+            if self._is_running_from_exe():
+                get_result = self._get_display_list_standalone()
+            else:
+                get_result = self._get_display_list_interpreted()
+
+            displays_json = json.loads(get_result)
+            new_list = [x['name'] for x in displays_json]
+            print(f'New temporary list: {new_list}')
+
+            if sorted(self._displays) != sorted(new_list):
+                self._displays = new_list
+                self.changed.emit(self._displays)
+
+        except Exception as e:
+            QMessageBox.information(None, "OSH Error", f"Error getting display list: {str(e)}")
+
+
+def get_display_list():
+    from PySide6.QtWidgets import QApplication
+    from PySide6.QtGui import QScreen
+    from typing import List
+    import json
+
+    app = QApplication([])
+    screens = app.screens()  # type: List[QScreen]
+
+    res = []
+    for screen in screens:
+        if len(screen.name()) == 0:
+            continue
+
+        res.append({
+            'name': screen.name(),
+            'model': screen.model(),
+            'serial': screen.serialNumber(),
+            'manufacturer': screen.manufacturer(),
+        })
+
+    print(json.dumps(res))
+
+
+if __name__ == '__main__':
+    get_display_list()


### PR DESCRIPTION
- Qt doesn't report display change events
- Getting a new display list requires starting another Qt process :facepalm: when switching between two main displays