### PR TITLE
Better handle OBS-related errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "obs-scene-helper"
-version = "0.2.0"
+version = "0.2.1"
 description = "OBS automatic scene and profile selection helper"
 readme = "README.md"
 authors = [

--- a/src/obs_scene_helper/controller/actions/pause_on_screen_lock.py
+++ b/src/obs_scene_helper/controller/actions/pause_on_screen_lock.py
@@ -71,7 +71,8 @@ class PauseOnScreenLock(QObject):
 
         self.log.info('Requesting pause')
         self.state = PauseOnScreenLock.State.WaitingForPauseEvent
-        self.obs_connection.recording.pause()
+        if not self.obs_connection.recording.pause():
+            self.state = PauseOnScreenLock.State.Idle
 
     def _handle_screen_unlocked(self):
         self.log.debug('Handling screen unlock event')
@@ -82,4 +83,5 @@ class PauseOnScreenLock(QObject):
 
         self.log.info('Requesting resumption')
         self.state = PauseOnScreenLock.State.WaitingForResumeEvent
-        self.obs_connection.recording.resume()
+        if not self.obs_connection.recording.resume():
+            self.state = PauseOnScreenLock.State.Idle

--- a/src/obs_scene_helper/controller/actions/switch_profile_and_scene_collection.py
+++ b/src/obs_scene_helper/controller/actions/switch_profile_and_scene_collection.py
@@ -102,7 +102,8 @@ class SwitchProfileAndSceneCollection(QObject):
         QThread.sleep(5)
 
         self.log.info(f"Switching profile: {self.target_preset.profile}")
-        self.obs_connection.profiles.set_active(self.target_preset.profile)
+        if not self.obs_connection.profiles.set_active(self.target_preset.profile):
+            self._transition_to_idle()
 
     def _handle_recording_started(self):
         self.log.debug(f'Recording started: {self.state}')
@@ -137,7 +138,8 @@ class SwitchProfileAndSceneCollection(QObject):
             return
 
         self.log.info(f"Starting recording")
-        self.obs_connection.recording.start()
+        if not self.obs_connection.recording.start():
+            self._transition_to_idle()
 
     def _handle_profile_change(self, _: str):
         self.log.debug(f'Profile change')
@@ -155,7 +157,8 @@ class SwitchProfileAndSceneCollection(QObject):
             return
 
         self.log.info(f"Switching scene collection: {self.target_preset.scene_collection}")
-        self.obs_connection.scene_collections.set_active(self.target_preset.scene_collection)
+        if not self.obs_connection.scene_collections.set_active(self.target_preset.scene_collection):
+            self._transition_to_idle()
 
     def _handle_display_list_change(self, _: List[str]):
         self.log.debug(f"Handling display list change")
@@ -198,7 +201,8 @@ class SwitchProfileAndSceneCollection(QObject):
                 self._handle_recording_stopped()
             else:
                 self.log.info(f"Stopping recording")
-                self.obs_connection.recording.stop()
+                if not self.obs_connection.recording.stop():
+                    self._transition_to_idle()
 
             return
 


### PR DESCRIPTION
- Mark connection as broken in case of any OBS-related errors.
- Return a boolean value in all the functions that control the OBS state.
- Handle failing OBS requests in actions.