### PR TITLE
Application settings + input fixing delay

### DIFF
--- a/src/obs_scene_helper/app.py
+++ b/src/obs_scene_helper/app.py
@@ -17,6 +17,7 @@ from obs_scene_helper.controller.system.log import Log as LogController
 
 from obs_scene_helper.view.tray_icon import TrayIcon
 from obs_scene_helper.view.settings.obs import OBSSettingsDialog
+from obs_scene_helper.view.settings.osh import OSHSettingsDialog
 from obs_scene_helper.view.widgets.preset_list import PresetList
 from obs_scene_helper.view.widgets.logs import Logs as LogsWidget
 
@@ -38,6 +39,7 @@ class OBSSceneHelperApp:
         self.tray_icon.signals.quit_requested.connect(self._close_requested)
         self.tray_icon.signals.presets_list_requested.connect(self._presets_list_requested)
         self.tray_icon.signals.obs_settings_requested.connect(self._obs_settings_requested)
+        self.tray_icon.signals.osh_settings_requested.connect(self._osh_settings_requested)
         self.tray_icon.signals.logs_requested.connect(self._logs_requested)
 
         self._setup_platform_specifics()
@@ -50,7 +52,7 @@ class OBSSceneHelperApp:
         if sys.platform == 'darwin':
             from obs_scene_helper.controller.actions.workarounds.macos.fix_inputs_after_recording_resume import \
                 FixInputsAfterRecordingResume
-            self.fix_macos_inputs = FixInputsAfterRecordingResume(self.obs_connection)
+            self.fix_macos_inputs = FixInputsAfterRecordingResume(self.obs_connection, self.settings)
 
         # Launch the connection after all the components are initialized, ensuring that all signals are received
         # by all the components
@@ -107,6 +109,10 @@ class OBSSceneHelperApp:
 
     def _obs_settings_requested(self):
         dialog = OBSSettingsDialog(self.settings)
+        dialog.exec()
+
+    def _osh_settings_requested(self):
+        dialog = OSHSettingsDialog(self.settings)
         dialog.exec()
 
     def _logs_requested(self):

--- a/src/obs_scene_helper/model/settings/osh.py
+++ b/src/obs_scene_helper/model/settings/osh.py
@@ -1,0 +1,51 @@
+from typing import Dict, Optional, Callable
+from dataclasses import dataclass, field
+
+
+@dataclass
+class OSH:
+    @dataclass
+    class MacOS:
+        fix_inputs_after_recording_resume_delay: int = 15
+
+    macos: MacOS = field(default_factory=lambda: OSH.MacOS())
+    _on_changed: Optional[Callable[[], None]] = field(default=None, init=False, repr=False, compare=False, hash=False)
+
+    def _notify_changed(self):
+        if self._on_changed is not None:
+            self._on_changed()
+
+    def to_json_dict(self) -> Dict:
+        return {
+            'macos': self.macos.__dict__
+        }
+
+    @staticmethod
+    def from_json_dict(val: Dict, on_changed: Optional[Callable[[], None]]) -> 'OSH':
+        macos = OSH.MacOS(**val['macos'])
+        osh = OSH(macos)
+        osh._on_changed = on_changed
+        return osh
+
+    def will_change_from(self, other: 'OSH'):
+        return self != other
+
+    @staticmethod
+    def make_default(on_changed: Optional[Callable[[], None]]) -> 'OSH':
+        osh = OSH()
+        osh._on_changed = on_changed
+        return osh
+
+    def copy(self, on_changed: Optional[Callable[[], None]]) -> 'OSH':
+        """ Make a copy of the settings instance """
+        osh = OSH(self.macos)
+        osh._on_changed = on_changed
+        return osh
+
+    def update(self, other: 'OSH'):
+        if self == other:
+            # Nothing changed
+            return
+
+        self.macos = other.macos
+        self._notify_changed()

--- a/src/obs_scene_helper/view/settings/osh.py
+++ b/src/obs_scene_helper/view/settings/osh.py
@@ -1,0 +1,64 @@
+from PySide6.QtWidgets import QDialog, QVBoxLayout, QFormLayout, QLineEdit, QSpinBox, QHBoxLayout, QPushButton
+from PySide6.QtWidgets import QDialogButtonBox, QMessageBox
+
+from obs_scene_helper.controller.settings.settings import Settings
+
+
+class OSHSettingsDialog(QDialog):
+    def __init__(self, settings: Settings, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.settings = settings
+        self.osh = settings.osh.copy(None)
+        self.setWindowTitle("OSH Settings")
+
+        main_layout = QVBoxLayout(self)
+        form_layout = QFormLayout()
+
+        # Create input fields
+        self.input_fix_delay = QSpinBox()
+        self.input_fix_delay.setRange(10, 60)
+        self.input_fix_delay.valueChanged.connect(self._input_fix_delay_changed)
+
+        # Add fields to form layout
+        form_layout.addRow("Input fix delay:", self.input_fix_delay)
+
+        # Action buttons
+        action_layout = QHBoxLayout()
+
+        # Create button box
+        button_box = QDialogButtonBox(QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel)
+        button_box.accepted.connect(self.accept)
+        button_box.rejected.connect(self.reject)
+
+        main_layout.addLayout(form_layout)
+        main_layout.addLayout(action_layout)
+        main_layout.addWidget(button_box)
+
+        self._load_current_values()
+        self._setup_tooltips()
+
+        self.setFixedSize(self.sizeHint())
+
+    def _load_current_values(self):
+        self.input_fix_delay.setValue(self.osh.macos.fix_inputs_after_recording_resume_delay)
+
+    def _setup_tooltips(self):
+        self.input_fix_delay.setToolTip(
+            "Time to wait before fiddling with macOS inputs after\n"
+            "the recording has resumed (in seconds)"
+        )
+
+    def _on_osh_changed(self):
+        if self.settings.osh.will_change_from(self.osh):
+            self.setWindowTitle("OSH Settings *")
+        else:
+            self.setWindowTitle("OSH Settings")
+
+    def _input_fix_delay_changed(self, value):
+        self.osh.macos.fix_inputs_after_recording_resume_delay = value
+        self._on_osh_changed()
+
+    def accept(self):
+        self.settings.osh.update(self.osh)
+        super().accept()

--- a/src/obs_scene_helper/view/tray_icon.py
+++ b/src/obs_scene_helper/view/tray_icon.py
@@ -13,6 +13,7 @@ class SystemTraySignals(QObject):
     quit_requested = Signal()
     presets_list_requested = Signal()
     obs_settings_requested = Signal()
+    osh_settings_requested = Signal()
     logs_requested = Signal()
 
 
@@ -36,6 +37,8 @@ class TrayIcon(QSystemTrayIcon):
         self.menu = QMenu()
         self.menu.addAction("Presets", lambda: self.signals.presets_list_requested.emit())
         self.menu.addAction("OBS Settings", lambda: self.signals.obs_settings_requested.emit())
+        self.menu.addSeparator()
+        self.menu.addAction("Settings", lambda: self.signals.osh_settings_requested.emit())
         self.menu.addAction("Logs", lambda: self.signals.logs_requested.emit())
         self.menu.addSeparator()
         self.menu.addAction("Quit", lambda: self.signals.quit_requested.emit())


### PR DESCRIPTION
Experiment with delaying the input fix on macOS to avoid an issue where the system takes a while to detect the display set change and then the application tries to fix the inputs while the preset is changing.